### PR TITLE
Added a Box that displays the value of a template's 'metadata.annotat…

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -241,6 +241,7 @@ catalog:
         - System
         - Domain
         - Location
+        - Template
   providers:
     backstageOpenapi:
       plugins:

--- a/plugins/scaffolder-backend/sample-templates/remote-templates.yaml
+++ b/plugins/scaffolder-backend/sample-templates/remote-templates.yaml
@@ -11,3 +11,4 @@ spec:
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/pull-request/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/react-ssr-template/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/springboot-grpc-template/template.yaml
+    - https://github.com/snippets-n-memes/backstage-expiriments/blob/master/template.yaml

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/CardHeader.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/CardHeader.tsx
@@ -92,9 +92,12 @@ export const CardHeader = (props: CardHeaderProps) => {
           position="absolute"
           right={0}
           bottom={0}
-          bgcolor="lightgrey"
+          bgcolor="yellow"
           p={0.5}
+          border={3}
+          borderColor="red"
           color="black"
+          fontWeight="900"
         >
           <CostComponent cost={cost} />
         </Box>

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/CardHeader.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/CardHeader.tsx
@@ -15,10 +15,18 @@
  */
 
 import React from 'react';
-import { Theme, makeStyles, useTheme } from '@material-ui/core';
+import { Theme, makeStyles, useTheme, Box } from '@material-ui/core';
 import { ItemCardHeader } from '@backstage/core-components';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { FavoriteEntity } from '@backstage/plugin-catalog-react';
+
+interface CostComponentProps {
+  cost: number;
+}
+
+const CostComponent: React.FC<CostComponentProps> = ({ cost }) => (
+  <div>{cost}</div>
+);
 
 const useStyles = makeStyles<
   Theme,
@@ -30,6 +38,7 @@ const useStyles = makeStyles<
   header: {
     backgroundImage: ({ cardBackgroundImage }) => cardBackgroundImage,
     color: ({ cardFontColor }) => cardFontColor,
+    position: 'relative',
   },
   subtitleWrapper: {
     display: 'flex',
@@ -54,6 +63,7 @@ export const CardHeader = (props: CardHeaderProps) => {
       spec: { type },
     },
   } = props;
+  const cost = props.template.metadata.annotations?.infracost;
   const { getPageTheme } = useTheme();
   const themeForType = getPageTheme({ themeId: type });
 
@@ -76,6 +86,19 @@ export const CardHeader = (props: CardHeaderProps) => {
       title={title ?? name}
       subtitle={SubtitleComponent}
       classes={{ root: styles.header }}
-    />
+    >
+      {cost ? (
+        <Box
+          position="absolute"
+          right={0}
+          bottom={0}
+          bgcolor="lightgrey"
+          p={0.5}
+          color="black"
+        >
+          <CostComponent cost={cost} />
+        </Box>
+      ) : null}
+    </ItemCardHeader>
   );
 };


### PR DESCRIPTION
**This is just a PoC, a person familiar with React can probably suggest a cleaner way to implement this. We can start here though**

Added a Box that displays the value of a template's 'metadata.annotations.infracost' property

![image](https://github.com/boxboat/backstage/assets/64292041/abf717a1-bb41-45dc-a3b0-0aada25d32a9)

I modified a [template.yaml here](https://github.com/snippets-n-memes/backstage-expiriments/blob/master/template.yaml) just for ease. public repo

app-config.yaml additions to allow templates in the catalog and a reference to the template above are the only configuration changes made to Backstage. 

Using `yarn dev` to run the example backstage app built for upstream contributions.

The goal here is to add this functionality to @backstage/plugin-scaffholder-react, build our own package (off this branch or off a merged main) and then maintain this fork just for this plugin right now. We will create a workflow in a sepearte repo to consume the plugin code from this repo, package and publish to NPM. 